### PR TITLE
Se/retry failed deletes

### DIFF
--- a/internal/server/storage/drivers/driver_truenas_utils.go
+++ b/internal/server/storage/drivers/driver_truenas_utils.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/lxc/incus/v6/shared/api"
+	"github.com/lxc/incus/v6/shared/logger"
 	"github.com/lxc/incus/v6/shared/revert"
 	"github.com/lxc/incus/v6/shared/subprocess"
 	"github.com/lxc/incus/v6/shared/util"
@@ -493,6 +495,36 @@ func (d *truenas) deleteSnapshot(snapshot string, recursive bool, options ...str
 	return d.deleteDataset(snapshot, recursive, options...)
 }
 
+// tryDeleteDataset attempts to delete a dataset, repeating if busy until success, or the context is ended
+func (d *truenas) tryDeleteBusyDataset(ctx context.Context, dataset string, recursive bool, options ...string) error {
+	for {
+		if ctx.Err() != nil {
+			return fmt.Errorf("Failed to delete dataset for %q: %w", dataset, ctx.Err())
+		}
+
+		// we sometimes we recieve a "busy" error when deleting... which I think is a race, although iSCSI should've finished with the zvol by the time
+		// deleteIscsiShare returns, maybe it hasn't yet... so we retry... in general if incus is calling deleteDataset it shouldn't be busy.
+		err := d.deleteDataset(dataset, recursive, options...)
+		if err == nil {
+			return nil
+		}
+
+		/*
+			Error -32001
+			Method call error
+			[EBUSY] Failed to delete dataset: cannot destroy '<dataset>': dataset is busy)
+		*/
+		if !strings.Contains(err.Error(), "[EBUSY]") {
+			return err
+		}
+
+		d.logger.Warn("Error while trying to delete dataset, will retry", logger.Ctx{"dataset": dataset, "err": err})
+
+		// was busy, lets try again.
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
 func (d *truenas) deleteDataset(dataset string, recursive bool, options ...string) error {
 	args := []string{d.getDatasetOrSnapshot(dataset), "delete"}
 
@@ -630,8 +662,10 @@ func (d *truenas) deleteDatasetRecursive(dataset string) error {
 		return err
 	}
 
-	// Delete the dataset (and any snapshots left).
-	err = d.deleteDataset(dataset, true)
+	// Try delete the dataset (and any snapshots left), waiting up to 5 seconds if its busy
+	ctx, cancel := context.WithTimeout(d.state.ShutdownCtx, 5*time.Second)
+	defer cancel()
+	err = d.tryDeleteBusyDataset(ctx, dataset, true)
 	if err != nil {
 		return err
 	}

--- a/internal/server/storage/drivers/driver_truenas_volumes.go
+++ b/internal/server/storage/drivers/driver_truenas_volumes.go
@@ -1553,7 +1553,9 @@ func (d *truenas) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) 
 
 	// Create a temporary clone from the snapshot.
 	err = d.cloneSnapshot(srcSnapshot, cloneDataset)
-
+	if err != nil {
+		return err
+	}
 	reverter.Add(func() { _ = d.deleteDatasetRecursive(cloneDataset) })
 
 	// and share the clone
@@ -1561,6 +1563,7 @@ func (d *truenas) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) 
 	if err != nil {
 		return err
 	}
+	reverter.Add(func() { _ = d.deleteIscsiShare(cloneDataset) })
 
 	// and then activate
 	volDevPath, err := d.activateIscsiDataset(cloneDataset)
@@ -1666,13 +1669,22 @@ func (d *truenas) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation
 
 	l.Debug("Deleting temporary TrueNAS snapshot volume")
 
-	// Deactivate
-	err = d.deactivateIscsiDataset(cloneDataset)
+	// Deactivate & Delete iSCSI share
+	err = d.deleteIscsiShare(cloneDataset)
 	if err != nil {
-		return false, fmt.Errorf("Could not deactivate temporary snapshot volume: %w", err)
+		return false, fmt.Errorf("Could not delete iscsi target for temporary snapshot volume: %w", err)
 	}
 
 	// Destroy clone
+
+	// TODO: we sometimes recieve a "busy" error here... which I think is a race, although iSCSI should've finished with the zvol by the time
+	// deleteIscsiShare returns, maybe it hasn't yet, Perhaps a retry loop with timeout?
+	/*
+		Error -32001
+		Method call error
+		[EBUSY] Failed to delete dataset: cannot destroy 'dozer/incus-tests/DMH/containers/c1-foo_c1-foo-snap0.incustmp': dataset is busy)
+	*/
+
 	err = d.deleteDatasetRecursive(cloneDataset)
 	if err != nil {
 		return false, fmt.Errorf("Could not delete temporary snapshot volume: %w", err)

--- a/internal/server/storage/drivers/driver_truenas_volumes.go
+++ b/internal/server/storage/drivers/driver_truenas_volumes.go
@@ -1678,15 +1678,6 @@ func (d *truenas) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation
 	}
 
 	// Destroy clone
-
-	// TODO: we sometimes recieve a "busy" error here... which I think is a race, although iSCSI should've finished with the zvol by the time
-	// deleteIscsiShare returns, maybe it hasn't yet, Perhaps a retry loop with timeout?
-	/*
-		Error -32001
-		Method call error
-		[EBUSY] Failed to delete dataset: cannot destroy 'dozer/incus-tests/DMH/containers/c1-foo_c1-foo-snap0.incustmp': dataset is busy)
-	*/
-
 	err = d.deleteDatasetRecursive(cloneDataset)
 	if err != nil {
 		return false, fmt.Errorf("Could not delete temporary snapshot volume: %w", err)


### PR DESCRIPTION
when deleting remote zvols, we sometimes see a busy error after they've been de-activated. This is probably a race condition. We now retry.

Additionally, a potential issue with remote snapshot temp names when the same snapshot is mounted on different members of the same cluster has been potentially resolved.